### PR TITLE
feat: New chat design

### DIFF
--- a/web/app/auth/layout.tsx
+++ b/web/app/auth/layout.tsx
@@ -11,9 +11,9 @@ export default async function AuthLayout({
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  
+
   return (
-    <main className='flex w-full max-w-lg flex-1 flex-col items-center justify-center'>
+    <main className='flex w-full max-w-lg flex-1 flex-col items-center justify-center px-3'>
       {children}
     </main>
   );

--- a/web/app/chat/[conversation_id]/page.tsx
+++ b/web/app/chat/[conversation_id]/page.tsx
@@ -58,9 +58,9 @@ export default async function Index({
   }
 
   return (
-    <div className='flex h-full w-full flex-col justify-start sm:w-2/3 sm:pl-2'>
+    <div className='flex h-full w-full flex-col justify-start gap-1 sm:w-2/3 sm:pl-4'>
       <ChatHeader currentUser={user as User} item={item as DBItem} />
-      <div className='flex h-full flex-col justify-end gap-2 overflow-y-scroll px-3 sm:px-0'>
+      <div className='flex h-full flex-col justify-end gap-1 overflow-hidden px-3 sm:px-0'>
         <Chat
           conversationId={conversationId}
           oldMessages={messages as DBMessage[]}

--- a/web/app/chat/layout.tsx
+++ b/web/app/chat/layout.tsx
@@ -4,6 +4,8 @@ import { createClient } from '@/utils/supabase/server';
 import { cookies } from 'next/headers';
 import { listUserConversations } from '@utils/lib/messaging/services';
 import { User } from '@supabase/supabase-js';
+import { Text } from '@/components/common/text';
+import { StyledLink } from '@/components/common/link';
 
 export default async function ChatLayout({
   children,
@@ -30,11 +32,27 @@ export default async function ChatLayout({
   }
 
   return (
-    <div className='flex h-[80vh] w-full overflow-hidden'>
-      <ChatProvider>
-        <ChatList conversations={conversations} currentUser={user as User} />
-        {children}
-      </ChatProvider>
-    </div>
+    <ChatProvider>
+      {conversations.length > 0 ? (
+        <div className='flex h-[80vh] w-full overflow-hidden'>
+          <ChatList conversations={conversations} currentUser={user as User} />
+          {children}
+        </div>
+      ) : (
+        <div className='my-10 flex w-full max-w-[700px] flex-col items-center justify-start gap-10 px-3 text-center'>
+          <Text variant='h3'>You don&apos;t have any conversations yet</Text>
+          <Text variant='body' className='mx-5'>
+            Found a lost object? Scan its QR Code to start a chat with its owner
+            ! Or, if you&apos;ve lost something, wait for someone to find it and
+            contact you!
+          </Text>
+          <StyledLink
+            variant='secondary'
+            text='Return home'
+            href='/'
+          ></StyledLink>
+        </div>
+      )}
+    </ChatProvider>
   );
 }

--- a/web/app/dashboard/layout.tsx
+++ b/web/app/dashboard/layout.tsx
@@ -4,7 +4,7 @@ export default async function DashboardLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className='flex w-full flex-1 flex-col items-center justify-start'>
+    <div className='flex w-full flex-1 flex-col items-center justify-start px-3'>
       {children}
     </div>
   );

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -23,14 +23,14 @@ export default function RootLayout({
   return (
     <html lang='en' className={GeistSans.className}>
       <NotificationProvider>
-        <body className='flex h-screen w-full flex-col items-center justify-between gap-2 bg-zinc-50 dark:bg-zinc-800 sm:gap-5'>
+        <body className='flex h-screen max-h-screen w-full flex-col items-center justify-start gap-2 bg-zinc-50 dark:bg-zinc-800 sm:gap-5'>
           <nav className='dark:bg-dark-200 flex h-16 w-full justify-center border-b border-b-stone-300 bg-zinc-100 dark:border-b-stone-700 dark:bg-zinc-900'>
             <div className='flex w-full max-w-4xl items-center justify-between p-3 text-sm'>
               <Navbar />
             </div>
           </nav>
 
-          <main className='animate-in flex w-full max-w-4xl flex-1 flex-col items-center gap-20 px-0 opacity-0 sm:px-3'>
+          <main className='animate-in flex w-full max-w-5xl flex-1 flex-col items-center gap-20 px-0 opacity-0 sm:px-3'>
             {children}
           </main>
 

--- a/web/app/scan/[qrcode_id]/page.tsx
+++ b/web/app/scan/[qrcode_id]/page.tsx
@@ -15,7 +15,7 @@ export default async function Scan({
   const { data: qrCode, error } = await getQRCode(supabase, params.qrcode_id);
 
   return (
-    <div className='flex w-full flex-1 flex-col items-center justify-center gap-20'>
+    <div className='flex w-full flex-1 flex-col items-center justify-center gap-20 px-3'>
       <div className='flex w-full flex-col items-center justify-center gap-2'>
         {qrCode?.item_id ? (
           <>

--- a/web/app/user/layout.tsx
+++ b/web/app/user/layout.tsx
@@ -10,7 +10,7 @@ export default async function UserLayout({ children }: { children: any }) {
   } = await supabase.auth.getUser();
 
   return (
-    <div className='flex w-full flex-1 flex-col items-start justify-between gap-2 md:flex-row'>
+    <div className='flex w-full flex-1 flex-col items-start justify-between gap-2 px-3 md:flex-row'>
       {children}
       <NotificationList user_id={user?.id as string} />
     </div>

--- a/web/components/chat/ChatCard.tsx
+++ b/web/components/chat/ChatCard.tsx
@@ -159,7 +159,7 @@ export default function ChatCard({
 
       <div className='flex-grow truncate'>
         <Text variant={'h4'} className='truncate'>
-          {itemInfo?.name || 'unknown'}
+          {itemInfo?.name || 'Item found'}
         </Text>
         <div className='flex items-center'>
           <Text variant={'body'} className='truncate'>

--- a/web/components/chat/ChatCard.tsx
+++ b/web/components/chat/ChatCard.tsx
@@ -116,7 +116,7 @@ export default function ChatCard({
 
   const selectedStyle =
     selectedConversationId === conversation?.id
-      ? ' bg-zinc-100 dark:bg-zinc-600'
+      ? ' bg-zinc-100 dark:bg-zinc-800/70'
       : '';
 
   // ! Same here, we can't get the item info when we are the finder
@@ -136,7 +136,7 @@ export default function ChatCard({
     <Link
       href={/chat/ + conversation.id}
       key={conversation.id}
-      className={`flex items-center gap-2 rounded-br-xl rounded-tr-xl px-4 py-3 hover:bg-zinc-100 dark:hover:bg-zinc-600 ${selectedStyle} `}
+      className={`flex items-center gap-2 rounded-br-lg rounded-tr-lg px-4 py-3 hover:bg-zinc-100 dark:hover:bg-zinc-800/70 ${selectedStyle} `}
     >
       <div className='flex-shrink-0'>
         {avatarUrl ? (
@@ -162,7 +162,11 @@ export default function ChatCard({
           {itemInfo?.name || 'Item found'}
         </Text>
         <div className='flex items-center'>
-          <Text variant={'body'} className='truncate'>
+          <Text
+            variant={'body'}
+            className='truncate'
+            color='text-black dark:text-stone-100'
+          >
             {lastMessage?.sender_id === currentUser?.id ? 'You: ' : ''}
             {lastMessage?.content || 'No messages yet'}
           </Text>
@@ -171,7 +175,7 @@ export default function ChatCard({
 
       <div className='flex flex-shrink-0 flex-col items-end gap-1'>
         {renderTag()}
-        <Text variant={'caption'} className='text-black/70'>
+        <Text variant={'caption'} color='text-black/90 dark:text-stone-100/70'>
           {displayLastMessageDate()}
         </Text>
       </div>

--- a/web/components/chat/ChatCard.tsx
+++ b/web/components/chat/ChatCard.tsx
@@ -116,7 +116,7 @@ export default function ChatCard({
 
   const selectedStyle =
     selectedConversationId === conversation?.id
-      ? ' bg-gray-700/10 dark:bg-white/20 '
+      ? ' bg-zinc-100 dark:bg-zinc-600'
       : '';
 
   // ! Same here, we can't get the item info when we are the finder
@@ -136,7 +136,7 @@ export default function ChatCard({
     <Link
       href={/chat/ + conversation.id}
       key={conversation.id}
-      className={`${selectedStyle} flex items-center gap-2 px-2 py-3 hover:bg-gray-700/10 dark:hover:bg-white/20`}
+      className={`flex items-center gap-2 rounded-br-xl rounded-tr-xl px-4 py-3 hover:bg-zinc-100 dark:hover:bg-zinc-600 ${selectedStyle} `}
     >
       <div className='flex-shrink-0'>
         {avatarUrl ? (
@@ -171,7 +171,9 @@ export default function ChatCard({
 
       <div className='flex flex-shrink-0 flex-col items-end gap-1'>
         {renderTag()}
-        <Text variant={'caption'}>{displayLastMessageDate()}</Text>
+        <Text variant={'caption'} className='text-black/70'>
+          {displayLastMessageDate()}
+        </Text>
       </div>
     </Link>
   );

--- a/web/components/chat/ChatHeader.tsx
+++ b/web/components/chat/ChatHeader.tsx
@@ -72,7 +72,7 @@ export default function ChatHeader({ currentUser, item }: MobileHeaderProps) {
 
   return (
     <>
-      <div className='flex items-center gap-2 pb-2 shadow-md dark:shadow-black/20 sm:pl-6 sm:shadow-none'>
+      <div className='mx-3 flex items-center gap-2 rounded-2xl bg-zinc-100 py-3 shadow-md dark:bg-zinc-700 dark:shadow-black/20 sm:mx-0 sm:pl-6 sm:shadow-none'>
         <Link href='/chat' className='flex sm:hidden'>
           <Icon
             name={'chevron-left'}

--- a/web/components/chat/ChatHeader.tsx
+++ b/web/components/chat/ChatHeader.tsx
@@ -72,7 +72,7 @@ export default function ChatHeader({ currentUser, item }: MobileHeaderProps) {
 
   return (
     <>
-      <div className='mx-3 flex items-center gap-2 rounded-2xl bg-zinc-100 py-3 shadow-md dark:bg-zinc-700 dark:shadow-black/20 sm:mx-0 sm:pl-6 sm:shadow-none'>
+      <div className='mx-3 flex items-center gap-2 rounded-lg border border-zinc-200 bg-zinc-100 py-3 shadow-md dark:border-zinc-700 dark:bg-zinc-900 dark:shadow-black/20 sm:mx-0 sm:pl-6 sm:shadow-none'>
         <Link href='/chat' className='flex sm:hidden'>
           <Icon
             name={'chevron-left'}

--- a/web/components/chat/ChatList.tsx
+++ b/web/components/chat/ChatList.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useState, useEffect } from 'react';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import { Text } from '../common/text';
 import ChatCard from './ChatCard';
 import { User } from '@supabase/supabase-js';
@@ -13,6 +13,7 @@ export default function ChatList({
   conversations,
   currentUser,
 }: ChatListProps) {
+  const router = useRouter();
   const selectedConversationId = useParams().conversation_id as string;
   const [ownedConversations, setOwnedConversations] = useState<
     TConversationWithLastMessage[] | null
@@ -31,6 +32,15 @@ export default function ChatList({
     );
     setLoading(false);
   }, [conversations, currentUser]);
+
+  // display the last conversation when loading chat page (if exist)
+  if (
+    !selectedConversationId &&
+    conversations.length > 0 &&
+    conversations[0].id
+  ) {
+    router.push(`/chat/${conversations[0].id}`);
+  }
 
   const renderConversations = (
     conversationsList: TConversationWithLastMessage[]

--- a/web/components/chat/ChatList.tsx
+++ b/web/components/chat/ChatList.tsx
@@ -58,7 +58,7 @@ export default function ChatList({
         <Text variant={'h2'}>Conversations</Text>
       </div>
 
-      <div className='flex h-full w-full flex-col gap-3 overflow-y-auto rounded-3xl bg-white py-4 dark:bg-zinc-700'>
+      <div className='flex h-full w-full flex-col gap-3 overflow-y-auto rounded-lg border border-zinc-200 bg-white py-4 dark:border-zinc-700 dark:bg-zinc-900'>
         {!conversations || loading ? (
           <ChatListSkeleton />
         ) : (

--- a/web/components/chat/ChatList.tsx
+++ b/web/components/chat/ChatList.tsx
@@ -7,6 +7,7 @@ import { User } from '@supabase/supabase-js';
 import { TConversationWithLastMessage } from '@utils/lib/messaging/services';
 import { ChatListSkeleton } from './Skeletons';
 import { ChatListProps } from './types';
+import { Icon } from '../common/icon';
 
 export default function ChatList({
   conversations,
@@ -47,44 +48,48 @@ export default function ChatList({
     });
   };
 
-  const mobileStyle = selectedConversationId ? ' hidden sm:block ' : '';
+  const mobileStyle = selectedConversationId ? ' hidden sm:flex ' : '';
 
   return (
     <div
-      className={`flex h-full w-full flex-col border-gray-700/10 px-3 dark:border-white/20 sm:w-1/3 sm:border-r-[1px] sm:px-0 ${mobileStyle}`}
+      className={`${mobileStyle} flex w-full flex-1 flex-col gap-3 px-5 sm:w-1/3 sm:px-2`}
     >
-      <Text variant={'h2'} className='p-2'>
-        Conversations
-      </Text>
+      <div className='my-5 ml-3 flex justify-start'>
+        <Text variant={'h2'}>Conversations</Text>
+      </div>
 
-      {!conversations || loading ? (
-        <ChatListSkeleton />
-      ) : (
-        <>
-          {ownedConversations && ownedConversations.length > 0 && (
-            <>
-              <Text
-                variant={'h4'}
-                className='border-b-[1px] border-gray-700/10 px-2 pb-1 pt-2 dark:border-white/20'
-              >
-                My items
-              </Text>
-              {renderConversations(ownedConversations)}
-            </>
-          )}
-          {foundConversations && foundConversations.length > 0 && (
-            <>
-              <Text
-                variant={'h4'}
-                className='border-b-[1px] border-gray-700/10 px-2 pb-1 pt-2 dark:border-white/20'
-              >
-                Items scanned
-              </Text>
-              {renderConversations(foundConversations)}
-            </>
-          )}
-        </>
-      )}
+      <div className='flex h-full w-full flex-col gap-3 overflow-y-auto rounded-3xl bg-white py-4 dark:bg-zinc-700'>
+        {!conversations || loading ? (
+          <ChatListSkeleton />
+        ) : (
+          <>
+            {ownedConversations && ownedConversations.length > 0 && (
+              <div className='flex flex-col gap-1'>
+                <Text
+                  variant={'subtitle'}
+                  className='flex items-center gap-2 py-2 pl-3'
+                >
+                  <Icon name='user' size={20} />
+                  My items
+                </Text>
+                {renderConversations(ownedConversations)}
+              </div>
+            )}
+            {foundConversations && foundConversations.length > 0 && (
+              <div className='flex flex-col gap-1'>
+                <Text
+                  variant={'subtitle'}
+                  className='flex items-center gap-2 py-2 pl-3'
+                >
+                  <Icon name='qrcode' size={20} />
+                  Items scanned
+                </Text>
+                {renderConversations(foundConversations)}
+              </div>
+            )}
+          </>
+        )}
+      </div>
     </div>
   );
 }

--- a/web/components/chat/ChatList.tsx
+++ b/web/components/chat/ChatList.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect } from 'react';
 import { useParams, useRouter } from 'next/navigation';
 import { Text } from '../common/text';
 import ChatCard from './ChatCard';
@@ -22,6 +22,11 @@ export default function ChatList({
     TConversationWithLastMessage[] | null
   >(null);
   const [loading, setLoading] = useState<boolean>(true);
+  const [isMobile, setIsMobile] = useState<boolean>(window.innerWidth < 640);
+
+  useLayoutEffect(() => {
+    setIsMobile(window.innerWidth < 640);
+  }, [setIsMobile]);
 
   useEffect(() => {
     setOwnedConversations(
@@ -37,7 +42,8 @@ export default function ChatList({
   if (
     !selectedConversationId &&
     conversations.length > 0 &&
-    conversations[0].id
+    conversations[0].id &&
+    !isMobile
   ) {
     router.push(`/chat/${conversations[0].id}`);
   }

--- a/web/components/chat/Input.tsx
+++ b/web/components/chat/Input.tsx
@@ -48,7 +48,7 @@ const Input = ({ conversationId }: InputChatProps) => {
         onChange={(e) => {
           setValue(e.target.value);
         }}
-        className='w-full bg-transparent focus:outline-none'
+        className='w-full bg-transparent text-black focus:outline-none dark:text-white'
       />
 
       <div className='mx-2 flex h-10 w-10 cursor-pointer items-center justify-center'>

--- a/web/components/chat/Input.tsx
+++ b/web/components/chat/Input.tsx
@@ -9,6 +9,7 @@ import { insertMessage } from '@utils/lib/messaging/services';
 const Input = ({ conversationId }: InputChatProps) => {
   const supabase = createClient();
   const [value, setValue] = useState('');
+  const [focus, setFocus] = useState(false);
 
   async function sendMessage(e: any) {
     e.preventDefault();
@@ -39,16 +40,18 @@ const Input = ({ conversationId }: InputChatProps) => {
   return (
     <form
       onSubmit={sendMessage}
-      className='flex w-full rounded-full bg-white py-1 pl-6 pr-2 dark:bg-zinc-700'
+      className='flex w-full rounded-full border border-zinc-200 bg-white py-1 pl-6 pr-2 dark:border-zinc-600 dark:bg-zinc-800'
     >
       <input
         name='message'
-        placeholder='Type a message'
+        placeholder={focus ? '' : 'Type a message...'}
         value={value}
         onChange={(e) => {
           setValue(e.target.value);
         }}
         className='w-full bg-transparent text-black focus:outline-none dark:text-white'
+        onFocus={() => setFocus(true)}
+        onBlur={() => setFocus(false)}
       />
 
       <div className='mx-2 flex h-10 w-10 cursor-pointer items-center justify-center'>

--- a/web/components/chat/Input.tsx
+++ b/web/components/chat/Input.tsx
@@ -37,14 +37,18 @@ const Input = ({ conversationId }: InputChatProps) => {
   }
 
   return (
-    <form onSubmit={sendMessage} className='flex sm:pl-6'>
-      <InputText
+    <form
+      onSubmit={sendMessage}
+      className='flex w-full rounded-full bg-white py-1 pl-6 pr-2 dark:bg-zinc-700'
+    >
+      <input
         name='message'
         placeholder='Type a message'
         value={value}
         onChange={(e) => {
           setValue(e.target.value);
         }}
+        className='w-full bg-transparent focus:outline-none'
       />
 
       <div className='mx-2 flex h-10 w-10 cursor-pointer items-center justify-center'>

--- a/web/components/chat/Message.tsx
+++ b/web/components/chat/Message.tsx
@@ -1,6 +1,7 @@
 'use client';
 import dateFormat, { masks } from 'dateformat';
 import { MessageProps } from './types';
+import { Text } from '../common/text';
 
 masks.timeOnly = 'HH:MM';
 masks.dateOnly = 'd mmm yyyy';
@@ -88,9 +89,9 @@ const Message = ({
           <div>{message.content}</div>
         </div>
         {lastMessage ? (
-          <div className='px-2 pt-1 text-sm font-light'>
+          <Text variant={'caption'} className='px-2 pt-1 text-black/70'>
             {dateFormat(message.created_at, masks.timeOnly)}
-          </div>
+          </Text>
         ) : null}
       </div>
     </>

--- a/web/components/chat/Message.tsx
+++ b/web/components/chat/Message.tsx
@@ -89,7 +89,11 @@ const Message = ({
           <div>{message.content}</div>
         </div>
         {lastMessage ? (
-          <Text variant={'caption'} className='px-2 pt-1 text-black/70'>
+          <Text
+            variant={'caption'}
+            className='px-2 pt-1'
+            color='text-black/90 dark:text-white/70'
+          >
             {dateFormat(message.created_at, masks.timeOnly)}
           </Text>
         ) : null}

--- a/web/components/chat/Skeletons.tsx
+++ b/web/components/chat/Skeletons.tsx
@@ -2,8 +2,8 @@ const skeletonStyle = 'animate-pulse bg-gray-300/50 dark:bg-gray-300/20';
 
 export const ChatListSkeleton = () => {
   return (
-    <div className={`flex h-full w-full flex-col gap-2 pr-4`}>
-      <div className={`${skeletonStyle} h-6 w-1/2 rounded-lg pb-6`}></div>
+    <div className={`flex h-full w-full flex-col gap-2`}>
+      <div className={`${skeletonStyle} ml-4 h-6 w-1/2 rounded-lg pb-6`}></div>
       {[...Array(8)].map((_, index) => (
         <ChatCardSkeleton key={index} />
       ))}

--- a/web/components/common/icon/constant.ts
+++ b/web/components/common/icon/constant.ts
@@ -25,6 +25,7 @@ import {
   IconExternalLink,
   IconExclamationCircle,
   IconAlertTriangle,
+  IconUser,
 } from '@tabler/icons-react';
 
 const ICONS = {
@@ -54,6 +55,7 @@ const ICONS = {
   'external-link': IconExternalLink,
   'exclamation-circle': IconExclamationCircle,
   'alert-triangle': IconAlertTriangle,
+  user: IconUser,
 };
 
 export default ICONS;


### PR DESCRIPTION
Close #75 
## Better design for the chat

### TODO : 
- [x] Redirect to first chat when loading /chat (desktop only)
- [x] Handle empty conversation list

### Old :
![image](https://github.com/victorbillaud/tomato/assets/91191933/f8e33cb8-dead-4133-813a-493b50d8ce70)
![image](https://github.com/victorbillaud/tomato/assets/91191933/8bff6d52-2a41-4ae0-bb4e-8aa33a6dd109)
![image](https://github.com/victorbillaud/tomato/assets/91191933/e2596d3b-6109-4d80-b55b-3ceb483494eb)

### New :
![image](https://github.com/victorbillaud/tomato/assets/91191933/5e0d0886-51fd-42b5-810d-f22d26ea6412)
![image](https://github.com/victorbillaud/tomato/assets/91191933/9b115db9-02e2-47b3-89e0-fb557328889b)
![image](https://github.com/victorbillaud/tomato/assets/91191933/ed2b9fc5-372c-428c-ad79-86a0dce7702d)

### Gestion dans le cas d'une liste de conversation vide :
![image](https://github.com/victorbillaud/tomato/assets/91191933/d66ba5ef-8e7d-40e2-b083-9ac3ba754059)
